### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,21 @@ env:
   - TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install: 
+  - |
+    if [ "$TOXENV" = "pypy" ]; then
+      export PYENV_ROOT="$HOME/.pyenv"
+      if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+        cd "$PYENV_ROOT" && git pull
+      else
+        rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+      fi
+      export PYPY_VERSION="4.0.1"
+      "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
+      virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+      source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+    fi
+  - pip install -U tox
 
 # command to run tests, e.g. python setup.py test
 script: tox -e ${TOXENV}

--- a/contributors/cli.py
+++ b/contributors/cli.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 from datetime import datetime, tzinfo, timedelta
 
 import click

--- a/contributors/contributors.py
+++ b/contributors/contributors.py
@@ -14,6 +14,8 @@
 
 """
 
+from __future__ import print_function
+
 from datetime import datetime
 from os import environ
 


### PR DESCRIPTION
With a couple of `__future__` imports and some travis-ci trickery (`pypy` on travis is outdated), all tests pass. Credit to https://github.com/travis-ci/travis-ci/issues/5027#issuecomment-170939193 for the workaround. Fixes #4.

Note: this method of installing pypy is ugly and should be dropped once travis upgrades its default version.