### PR TITLE
Allow unauthenticated GitHub API calls

### DIFF
--- a/contributors/contributors.py
+++ b/contributors/contributors.py
@@ -18,11 +18,13 @@ from __future__ import print_function
 
 from os import environ
 
-from github3 import login
+from github3 import GitHub
 
 
-gh = login(token=environ.get('GITHUB_API_SECRET'))
-assert gh, "Make sure GITHUB_API_SECRET is available in env var"
+gh = GitHub()
+token = environ.get('GITHUB_API_SECRET')
+if token:
+    gh.login(token=token)
 
 
 def get_markdown_output(contributors):

--- a/tests/test_contributors.py
+++ b/tests/test_contributors.py
@@ -25,12 +25,12 @@ class TestContributors(object):
 
     def test_something(self):
         pass
-        
+
     def test_command_line_interface_help(self):
         runner = CliRunner()
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
-        assert '-h, --help        Show this message and exit.' in help_result.output
+        assert '-h, --help             Show this message and exit.' in help_result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
The GitHub API allows unauthenticated requests (but imposes a lower rate
limit on these clients). This change allows the user to run the CLI tool
without supplying credentials.

In the future, it would be nice to support authentication via all of the
methods provided by the `github3.py` API (username and password, token,
two-factor support) via both command-line flags and environment
variables.

This change should make travis-ci happy again (tests were failing
because of a lack of the `GITHUB_API_SECRET` environment variable).

----

Additionally, fix failing `--help` test.

Due to changes in the command line interface, the `--help` flag test
fails due to the expected whitespace in the output. A better, long-term
fix would be whitespace independent, but this change satisfies travis-ci
for now.