### PR TITLE
Fix input equality check when rate-limited

### DIFF
--- a/contributors/contributors.py
+++ b/contributors/contributors.py
@@ -95,7 +95,7 @@ def get_contribitors(repo_names, since=None, until=None, format='rst'):
 
     if gh.ratelimit_remaining < 1000:
         proceed = input("Your GitHub rate limit is below 1000. Continue? (y/n)")
-        if proceed.lower() is not 'y':
+        if proceed.lower() != 'y':
             return
 
     contributors = set([])


### PR DESCRIPTION
This line currently causes `get_contributors` to always return `None`
and the CLI tool to raise an exception. Comparing equality instead of
identity addresses the issue.