### PR TITLE
Declare Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,26 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.5
 
-env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
-  - TOXENV=py27
-  - TOXENV=py26
-  - TOXENV=pypy
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 2.6
+      env: TOXENV=py26
+    - python: pypy-5.4
+      env: TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: 
-  - |
-    if [ "$TOXENV" = "pypy" ]; then
-      export PYENV_ROOT="$HOME/.pyenv"
-      if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
-        cd "$PYENV_ROOT" && git pull
-      else
-        rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
-      fi
-      export PYPY_VERSION="4.0.1"
-      "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
-      virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
-      source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
-    fi
-  - pip install -U tox
+install: pip install -U tox
 
 # command to run tests, e.g. python setup.py test
 script: tox -e ${TOXENV}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py26, py27, py33, py34, py35, py36, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
- Add Python 3.6 to `tox.ini` and `.travis.yml`
- Switch travis builds from env list to build matrix to work around
  issues regarding Python version availability in default build
  environments
- Install an up-to-date version of pypy in a less hacky way (undoes some
  of my changes from #7)