### PR TITLE
Fix click tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
       else
         rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
       fi
-      export PYPY_VERSION="4.0.1"
+      export PYPY_VERSION="5.4"
       "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
       virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
       source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"

--- a/tests/test_contributors.py
+++ b/tests/test_contributors.py
@@ -30,7 +30,8 @@ class TestContributors(object):
         runner = CliRunner()
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
-        assert '-h, --help             Show this message and exit.' in help_result.output
+        assert '-h, --help' in help_result.output
+        assert 'Show this message and exit.' in help_result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
The help output generated by click appears to have changed at some
point. Instead of depending on a certain number of spaces in the help
line, simply check for the flag string and the description string
separately. This should (theoretically) be less fragile against future
updates. Additionally, bump pypy version to address `cryptography` support
issue.