### PR TITLE
Fix typo in get_contributors function name

### DIFF
--- a/contributors/cli.py
+++ b/contributors/cli.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from datetime import datetime, tzinfo, timedelta
 import click
 
-from .contributors import get_contribitors
+from .contributors import get_contributors
 from contributors import __version__
 
 
@@ -48,7 +48,7 @@ def main(repo_names, since, until, format, filename):
         since = datetime(2012, 6, 2, tzinfo=EST())
     if until is None:
         until = datetime.now(EST())
-    output = get_contribitors(repo_names, since=since, until=until, format=format)
+    output = get_contributors(repo_names, since=since, until=until, format=format)
     click.echo('\nSaving results to %s' % filename)
     with open(filename, 'w') as f:
         f.write(output)

--- a/contributors/contributors.py
+++ b/contributors/contributors.py
@@ -95,7 +95,7 @@ def get_output_text(contributors, format):
     return mapping[format](contributors)
 
 
-def get_contribitors(repo_names, since=None, until=None, format='rst'):
+def get_contributors(repo_names, since=None, until=None, format='rst'):
     """
     :param repo_names: List of GitHub repos, each named thus:
                         ['audreyr/cookiecutter', 'pydanny/contributors']


### PR DESCRIPTION
Change `get_contribitors` to `get_contributors`.

@pydanny This one is a tricky situation. If anyone is using `contributors` as a library, this is a breaking change and should be treated as such. So, a few questions:

1. Are you interested in this change?
2. Do you have a sense of whether or not anyone uses the project in this fashion and would be affected? (I don't want to break people's builds.)
3. If you'd like to accept the change but want to treat is as breaking, should I add something to the changelog under a new version entry? Alternatively, does this just not matter, since the project is pre-1.0 and subject to breaking changes until a stable API is declared?