### PR TITLE
[WIP] Add gitlab support

### DIFF
--- a/contributors/cli.py
+++ b/contributors/cli.py
@@ -35,7 +35,11 @@ class EST(tzinfo):
     u'-o', u'--output', u'filename', default=None,
     help=u'Output will be written to this file.'
 )
-def main(repo_names, since, until, format, filename):
+@click.option(
+    u'-h', u'--host', u'host', default=u'github', type=click.Choice(('github', 'gitlab')),
+    help=u'Hosting service where repositories are located.'
+)
+def main(repo_names, since, until, format, filename, host):
     """Console script for contributors"""
     # If the filename is not provided, build a default using the format
     if filename is None:
@@ -48,7 +52,8 @@ def main(repo_names, since, until, format, filename):
         since = datetime(2012, 6, 2, tzinfo=EST())
     if until is None:
         until = datetime.now(EST())
-    output = get_contribitors(repo_names, since=since, until=until, format=format)
+    output = get_contribitors(
+        repo_names, since=since, until=until, format=format, host=host)
     click.echo('\nSaving results to %s' % filename)
     with open(filename, 'w') as f:
         f.write(output)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'Click>=6.0',
-    'github3.py==1.0.0a4'
+    'github3.py==1.0.0a4',
+    'python-gitlab',
 ]
 
 test_requirements = [


### PR DESCRIPTION
Add support for gitlab and pave the way for other hosts in the future.
This is a work in progress that needs cleanup and documentation, but
it's a start.

Two main issues here:

1. The Gitlab API appears to require authentication. Users should be
   informed of this in the docs and when trying to use the tool without an
   API token.
2. The Gitlab API does not return User objects when requesting commits.
   In order to get rich user objects, we'll need to try to use the
   authors' names to search for appropriate users. Alternatively, we can
   simply use commit author names without trying to link to their
   accounts.

Fixes #15.